### PR TITLE
chore: Disable Logflare when variables missing

### DIFF
--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,10 +1,21 @@
 import { logflarePinoVercel } from '@atdrago/pino-logflare';
 import pino from 'pino';
 
-const { send, stream } = logflarePinoVercel({
-  apiKey: process.env.NEXT_PUBLIC_LOGFLARE_API_KEY,
-  sourceToken: process.env.NEXT_PUBLIC_LOGFLARE_SOURCE_TOKEN,
-});
+const sendToLogflare =
+  !!process.env.NEXT_PUBLIC_LOGFLARE_API_KEY &&
+  !!process.env.NEXT_PUBLIC_LOGFLARE_SOURCE_TOKEN;
+
+const { send, stream } = sendToLogflare
+  ? logflarePinoVercel({
+      apiKey: process.env.NEXT_PUBLIC_LOGFLARE_API_KEY,
+      sourceToken: process.env.NEXT_PUBLIC_LOGFLARE_SOURCE_TOKEN,
+    })
+  : {
+      send: () => {
+        // noop
+      },
+      stream: process.stdout,
+    };
 
 export const logger = pino(
   {
@@ -13,10 +24,12 @@ export const logger = pino(
       revision: process.env.VERCEL_GITHUB_COMMIT_SHA,
     },
     browser: {
-      transmit: {
-        level: 'info',
-        send,
-      },
+      transmit: sendToLogflare
+        ? {
+            level: 'info',
+            send,
+          }
+        : undefined,
       write: () => {
         // Prevent logs from being output to the browser console
       },


### PR DESCRIPTION
Setting up with the README was great, but I was getting runtime errors because I was missing the Logflare env vars. This removes the need for those during local dev. When they're missing it will use Pino's default stream (`process.stdout`) instead.